### PR TITLE
Updated Rules and Added Comments 

### DIFF
--- a/ELITEWOLF_SNORT_AllenBradley_RockwellAutomation.txt
+++ b/ELITEWOLF_SNORT_AllenBradley_RockwellAutomation.txt
@@ -1,14 +1,23 @@
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-TCP REQUEST"; content:"/rokform/advancedDiags?pageReq=tcp"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-SYSTEM DATA DETAIL"; content:"/rokform/SysDataDetail?name="; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-UDP TABLE"; content:"/rokform/advancedDiags?pageReq=udptable"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-TCP CONNECT"; content:"rokform/advancedDiags?pageReq=tcpconn"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-IP ROUTE"; content:"/rokform/advancedDiags?pageReq=iproute"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-GENERAL MEMORY"; content:"/rokform/advancedDiags?pageReq=genmem"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-HEAP REQUEST"; content:"/rokform/advancedDiags?pageReq=heap"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-ICMP REQUEST"; content:"/rokform/advancedDiags?pageReq=icmp"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-ARP REQUEST"; content:"/rokform/advancedDiags?pageReq=arp"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-UDP REQUEST"; content:"/rokform/advancedDiags?pageReq=udp"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-IF REQUEST"; content:"/rokform/advancedDiags?pageReq=if"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-IP REQUEST"; content:"/rokform/advancedDiags?pageReq=ip"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-CSS Path"; content:"/css/radevice.css"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-SYSTEM LIST DATA"; content:"/rokform/SysListDetail?name=";sid:1;rev:1;)
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for TCP REQUEST.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-TCP REQUEST Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=tcp"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1001; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for SYSTEM DATA DETAIL.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-SYSTEM DATA DETAIL Detected - Potential Security Concern"; content:"/rokform/SysDataDetail?name="; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1002; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for UDP TABLE.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-UDP TABLE Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=udptable"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1003; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for TCP CONNECT.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-TCP CONNECT Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=tcpconn"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1004; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for IP ROUTE.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-IP ROUTE Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=iproute"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1005; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for GENERAL MEMORY.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-GENERAL MEMORY Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=genmem"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1006; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for HEAP REQUEST.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-HEAP REQUEST Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=heap"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:1007; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 (HTTP) with a message about Allen-Bradley/Rockwell Automation URL Path Activity for ICMP REQUEST.
+alert tcp any any -> any 80 (msg: "ELITEWOLF Allen-Bradley/Rockwell Automation URL Path Activity-ICMP REQUEST Detected - Potential Security Concern"; content:"/rokform/advancedDiags?pageReq=icmp"; nocase; threshold: type limit, track by

--- a/ELITEWOLF_SNORT_SchweitzerEngineeringLaboratories.txt
+++ b/ELITEWOLF_SNORT_SchweitzerEngineeringLaboratories.txt
@@ -1,37 +1,98 @@
-alert tcp any 443 -> any any (msg: "ELITEWOLF SEL-3530-RTAC URL path activity - homepage"; content:"/home.sel"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg: "ELITEWOLF SEL-3530-RTAC URL path activity - LoginError"; content:"/errors/err401.sel?username="; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg: "ELITEWOLF SEL-3530-RTAC URL path activity - default.sel page"; content:"/default.sel"; sid:1; rev:1;)
-alert tcp any 1024 -> any any (msg: "ELITEWOLF SEL-3530-RTAC Possible SSH Login Activity"; content:"SSH-2.0-dropbear_2016.74"; sid:1; rev:1;)
-alert tcp any 5432 -> any any (msg: "ELITEWOLF SEL-3530-RTAC Possible AcSELerator Firmware Activity"; content:"SEL-3530 RTAC"; sid:1; rev:1;)
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-3530-RTAC URL path activity - homepage.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-3530-RTAC URL path activity - homepage Detected - Potential Security Concern"; content: "/home.sel"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10001; rev:1;)
 
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-3620 X509 certificate activity"; content: "http://www.sel-secure.com"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-3620 X509 certificate activity"; content: "commonname=http://www.sel-secure.com"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-3620 X509 certificate activity"; content: "issuer_CN: http://www.sel-secure.com"; sid:1; rev:1;)
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-3530-RTAC URL path activity - LoginError.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-3530-RTAC URL path activity - LoginError Detected - Potential Security Concern"; content: "/errors/err401.sel?username="; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10002; rev:1;)
 
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-2488 URL path activity"; content: "/scripts/dScripts.sel"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-2488 URL path activity"; content: "/css/sel.css?vid="; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-2488 X509 certificate activity"; content: "commonName=http://www.selinc.com/EthernetCommunications/"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg:"ELITEWOLF_SEL-2488 X509 certificate activity"; content: "issuer_CN: http://www.selinc.com/EthernetCommunications/"; sid:1; rev:1;)
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-3530-RTAC URL path activity - default.sel page.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-3530-RTAC URL path activity - default.sel page Detected - Potential Security Concern"; content: "/default.sel"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10003; rev:1;)
 
-alert tcp any 23 -> any any (msg:"ELITEWOLF SEL Telnet Activity"; pcre:"/SEL-[0-9]{3,4}/"; sid:1; rev:1;)
-alert tcp any 23 -> any any (msg:"ELITEWOLF SEL Access Level 1 Change"; content: "Level 1"; sid:1; rev:1;)
-alert tcp any 23 -> any any (msg:"ELITEWOLF SEL Access Level 2 Change"; content: "Level 2"; sid:1; rev:1;)
-alert tcp any 23 -> any any (msg:"ELITEWOLF SEL 2032 Processor"; content:"COMMUNICATIONS PROCESSOR-S/N"; sid:1; rev:1;)
-alert tcp any 23 -> any any (msg:"ELITEWOLF SEL Callibration Access Level Login Success"; content:"Calibration Access Established"; sid:1; rev:1;)
+# Alert on TCP traffic from any source to port 1024 with a message about Possible SSH Login Activity.
+alert tcp any any -> any 1024 (msg: "ELITEWOLF SEL-3530-RTAC Possible SSH Login Activity Detected - Potential Security Concern"; content: "SSH-2.0-dropbear_2016.74"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10004; rev:1;)
 
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Access Change"; content: "USER 2AC"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Change working directory 2701"; content: "CWD SEL-2701"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Change working directory 2701"; content: "CWD /SEL-2701"; sid:1; rev:1;)
-alert tcp any 21 -> any any (msg: "ELITEWOLF SEL FTP Activity - Current directory"; content: "/SEL-2701"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - RETR DNPMAP.TXT file"; content: "RETR DNPMAP.TXT"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - STOR SET_DNP1.TXT file"; content: "STOR SET_DNP1.TXT"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - potential file change"; content:"STOR SET_"; pcre:"/STOR SET_[0-9A-Z]{1,4}.TXT/"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Access Change ACC"; content: "USER ACC"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Password Login otter"; content: "PASS otter"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - STOR DNPMAP.TXT file"; content: "STOR DNPMAP.TXT"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - RETR ERR.TXT file"; content: "RETR ERR.TXT"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - RETR SET_DNP1.TXT file 2701"; content: "RETR SET_DNP1.TXT"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - File Retrieval"; content:"RETR SET_"; pcre:"/RETR SET_[0-9A-Z]{1,4}/"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Default Username"; content:"USER FTPUSER"; sid:1; rev:1;)
-alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Default Password"; content:"PASS TAIL"; sid:1; rev:1;)
-alert tcp any 21 -> any any (msg: "ELITEWOLF SEL-751A FTP SERVER"; content:"SEL-751A"; sid:1; rev:1;)
+# Alert on TCP traffic from any source to port 5432 with a message about Possible AcSELerator Firmware Activity.
+alert tcp any any -> any 5432 (msg: "ELITEWOLF SEL-3530-RTAC Possible AcSELerator Firmware Activity Detected - Potential Security Concern"; content: "SEL-3530 RTAC"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10005; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-3620 X509 certificate activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-3620 X509 certificate activity Detected - Potential Security Concern"; content: "http://www.sel-secure.com"; threshold: type limit, track by_src, count 5, seconds 60; sid:10006; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-3620 X509 certificate activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-3620 X509 certificate activity Detected - Potential Security Concern"; content: "commonname=http://www.sel-secure.com"; threshold: type limit, track by_src, count 5, seconds 60; sid:10007; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-3620 X509 certificate activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-3620 X509 certificate activity Detected - Potential Security Concern"; content: "issuer_CN: http://www.sel-secure.com"; threshold: type limit, track by_src, count 5, seconds 60; sid:10008; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-2488 URL path activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-2488 URL path activity Detected - Potential Security Concern"; content: "/scripts/dScripts.sel"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10009; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-2488 URL path activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-2488 URL path activity Detected - Potential Security Concern"; content: "/css/sel.css?vid="; threshold: type limit, track by_src, count 5, seconds 60; sid:10010; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-2488 X509 certificate activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-2488 X509 certificate activity Detected - Potential Security Concern"; content: "commonName=http://www.selinc.com/EthernetCommunications/"; threshold: type limit, track by_src, count 5, seconds 60; sid:10011; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 (HTTPS) with a message about SEL-2488 X509 certificate activity.
+alert tcp any any -> any 443 (msg: "ELITEWOLF SEL-2488 X509 certificate activity Detected - Potential Security Concern"; content: "issuer_CN: http://www.selinc.com/EthernetCommunications/"; threshold: type limit, track by_src, count 5, seconds 60; sid:10012; rev:1;)
+
+# Alert on TCP traffic from any source to port 23 (Telnet) with a message about SEL Telnet Activity.
+alert tcp any any -> any 23 (msg: "ELITEWOLF SEL Telnet Activity Detected - Potential Security Concern"; pcre: "/SEL-[0-9]{3,4}/"; threshold: type limit, track by_src, count 5, seconds 60; sid:10013; rev:1;)
+
+# Alert on TCP traffic from any source to port 23 (Telnet) with a message about SEL Access Level 1 Change.
+alert tcp any any -> any 23 (msg: "ELITEWOLF SEL Access Level 1 Change Detected - Potential Security Concern"; content: "Level 1"; threshold: type limit, track by_src, count 5, seconds 60; sid:10014; rev:1;)
+
+# Alert on TCP traffic from any source to port 23 (Telnet) with a message about SEL Access Level 2 Change.
+alert tcp any any -> any 23 (msg: "ELITEWOLF SEL Access Level 2 Change Detected - Potential Security Concern"; content: "Level 2"; threshold: type limit, track by_src, count 5, seconds 60; sid:10015; rev:1;)
+
+# Alert on TCP traffic from any source to port 23 (Telnet) with a message about SEL 2032 Processor.
+alert tcp any any -> any 23 (msg: "ELITEWOLF SEL 2032 Processor Detected - Potential Security Concern"; content: "COMMUNICATIONS PROCESSOR-S/N"; threshold: type limit, track by_src, count 5, seconds 60; sid:10016; rev:1;)
+
+# Alert on TCP traffic from any source to port 23 (Telnet) with a message about SEL Callibration Access Level Login Success.
+alert tcp any any -> any 23 (msg: "ELITEWOLF SEL Callibration Access Level Login Success Detected - Potential Security Concern"; content: "Calibration Access Established"; threshold: type limit, track by_src, count 5, seconds 60; sid:10017; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Access Change.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Access Change Detected - Potential Security Concern"; content: "USER 2AC"; threshold: type limit, track by_src, count 5, seconds 60; sid:10018; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Change working directory 2701.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Change working directory 2701 Detected - Potential Security Concern"; content: "CWD SEL-2701"; threshold: type limit, track by_src, count 5, seconds 60; sid:10019; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Change working directory 2701.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Change working directory 2701 Detected - Potential Security Concern"; content: "CWD /SEL-2701"; threshold: type limit, track by_src, count 5, seconds 60; sid:10020; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Current directory.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Current directory Detected - Potential Security Concern"; content: "/SEL-2701"; threshold: type limit, track by_src, count 5, seconds 60; sid:10021; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - RETR DNPMAP.TXT file.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - RETR DNPMAP.TXT file Detected - Potential Security Concern"; content: "RETR DNPMAP.TXT"; threshold: type limit, track by_src, count 5, seconds 60; sid:10022; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - STOR SET_DNP1.TXT file.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - STOR SET_DNP1.TXT file Detected - Potential Security Concern"; content: "STOR SET_DNP1.TXT"; threshold: type limit, track by_src, count 5, seconds 60; sid:10023; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - potential file change.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - potential file change Detected - Potential Security Concern"; content: "STOR SET_"; pcre: "/STOR SET_[0-9A-Z]{1,4}.TXT/"; threshold: type limit, track by_src, count 5, seconds 60; sid:10024; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Access Change ACC.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Access Change ACC Detected - Potential Security Concern"; content: "USER ACC"; threshold: type limit, track by_src, count 5, seconds 60; sid:10025; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Password Login otter.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Password Login otter Detected - Potential Security Concern"; content: "PASS otter"; threshold: type limit, track by_src, count 5, seconds 60; sid:10026; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - STOR DNPMAP.TXT file.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - STOR DNPMAP.TXT file Detected - Potential Security Concern"; content: "STOR DNPMAP.TXT"; threshold: type limit, track by_src, count 5, seconds 60; sid:10027; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - RETR ERR.TXT file.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - RETR ERR.TXT file Detected - Potential Security Concern"; content: "RETR ERR.TXT"; threshold: type limit, track by_src, count 5, seconds 60; sid:10028; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - RETR SET_DNP1.TXT file 2701.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - RETR SET_DNP1.TXT file 2701 Detected - Potential Security Concern"; content: "RETR SET_DNP1.TXT"; threshold: type limit, track by_src, count 5, seconds 60; sid:10029; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - File Retrieval.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - File Retrieval Detected - Potential Security Concern"; content: "RETR SET_"; pcre: "/RETR SET_[0-9A-Z]{1,4}/"; threshold: type limit, track by_src, count 5, seconds 60; sid:10030; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Default Username.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Default Username Detected - Potential Security Concern"; content: "USER FTPUSER"; threshold: type limit, track by_src, count 5, seconds 60; sid:10031; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL FTP Activity - Default Password.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL FTP Activity - Default Password Detected - Potential Security Concern"; content: "PASS TAIL"; threshold: type limit, track by_src, count 5, seconds 60; sid:10032; rev:1;)
+
+# Alert on TCP traffic from any source to port 21 (FTP) with a message about SEL-751A FTP SERVER.
+alert tcp any any -> any 21 (msg: "ELITEWOLF SEL-751A FTP SERVER Detected - Potential Security Concern"; content: "SEL-751A"; threshold: type limit, track by_src, count 5, seconds 60; sid:10033; rev:1;)

--- a/ELITEWOLF_SNORT_Siemens.txt
+++ b/ELITEWOLF_SNORT_Siemens.txt
@@ -1,5 +1,14 @@
-alert tcp any 80 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens Web Activity"; content:"/CSS/S7Web.css"; sid:1; rev:1;)
-alert tcp any 80 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens Web Activity"; content:"/Images/CPU1200/"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"S7-1200 Controller Family"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"commonName=S7-1200 Controller Family"; sid:1; rev:1;)
-alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"issuer_CN: S7-1200 Controller Family"; sid:1; rev:1;)
+# Alert on TCP traffic from any source to port 80 with a message about Possible Siemens S7-1200 Web Activity.
+alert tcp any 80 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens Web Activity Detected - Potential Security Concern"; content:"/CSS/S7Web.css"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10034; rev:1;)
+
+# Alert on TCP traffic from any source to port 80 with a message about Possible Siemens S7-1200 Web Activity.
+alert tcp any 80 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens Web Activity Detected - Potential Security Concern"; content:"/Images/CPU1200/"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10035; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 with a message about Possible Siemens S7-1200 X509 certificate activity.
+alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity Detected - Potential Security Concern"; content:"S7-1200 Controller Family"; threshold: type limit, track by_src, count 5, seconds 60; sid:10036; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 with a message about Possible Siemens S7-1200 X509 certificate activity.
+alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity Detected - Potential Security Concern"; content:"commonName=S7-1200 Controller Family"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10037; rev:1;)
+
+# Alert on TCP traffic from any source to port 443 with a message about Possible Siemens S7-1200 X509 certificate activity.
+alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity Detected - Potential Security Concern"; content:"issuer_CN: S7-1200 Controller Family"; nocase; threshold: type limit, track by_src, count 5, seconds 60; sid:10038; rev:1;)


### PR DESCRIPTION
## Why: 

- Enhance documentation, readability, and rule sets
- Limit excessive alerting to lower alert fatigue
- Collaborate as a community on these rules to better the ICS world

## What:

- `nocase` option was added to the rules where appropriate. This option makes the content matching case-insensitive, allowing the rules to match the specified content regardless of the letter case.
- **Thresholding for Generated Alerts:** Each rule includes thresholding to limit the number of alerts generated within a specific time frame. This helps prevent excessive alerts for the same event and provides a mechanism for detecting potentially suspicious patterns of activity
- **Unique SID Values:** The sid (Snort ID) values were updated to be unique within the set of rules. Previously, all rules had sid:1, which could lead to confusion and potential conflicts. In the modified rules, unique SID values were assigned to each rule to distinguish them from one another
- Corrected port values
- Added comments for readability and documentation
