### PR TITLE
Add SIMENS LOGO! bruteforce discovery rule. 

### DIFF
--- a/ELITEWOLF_SNORT_Siemens.txt
+++ b/ELITEWOLF_SNORT_Siemens.txt
@@ -4,4 +4,4 @@ alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 cert
 alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"commonName=S7-1200 Controller Family"; sid:1; rev:1;)
 alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"issuer_CN: S7-1200 Controller Family"; sid:1; rev:1;)
 
-alert tcp any any -> any 80 (msg:"ELITEWOLF SIEMENS LOGO! Attempted bruteforce on the web panel ";content:"POST /AJAX" ;content:"UAMLOGIN:"; threshold:type limit, track by_src, count 5, seconds 15; sid:1; rev:1;)
+alert tcp any any -> any 80 (msg:"ELITEWOLF SIEMENS LOGO! Attempted bruteforce on the web panel ";content:"POST /AJAX" ;content:"UAMCHAL:"; threshold:type limit, track by_src, count 5, seconds 15; sid:1; rev:1;)

--- a/ELITEWOLF_SNORT_Siemens.txt
+++ b/ELITEWOLF_SNORT_Siemens.txt
@@ -3,3 +3,5 @@ alert tcp any 80 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens Web Activi
 alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"S7-1200 Controller Family"; sid:1; rev:1;)
 alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"commonName=S7-1200 Controller Family"; sid:1; rev:1;)
 alert tcp any 443 -> any any (msg: "ELITEWOLF S7-1200 Possible Siemens X509 certificate activity"; content:"issuer_CN: S7-1200 Controller Family"; sid:1; rev:1;)
+
+alert tcp any any -> any 80 (msg:"ELITEWOLF SIEMENS LOGO! Attempted bruteforce on the web panel ";content:"POST /AJAX" ;content:"UAMLOGIN:"; threshold:type limit, track by_src, count 5, seconds 15; sid:1; rev:1;)


### PR DESCRIPTION
Add SIMENS LOGO! bruteforce discovery rule: (raised when more than 5 tentative in less than 15 seconds is made).

Here is presented the way in which the identifications are made on this PLC.  
https://github.com/jankeymeulen/siemens-logo-rest 


We can see a bruteforce pattern using the "UAMLOGIN" or "UAMLOGIN" field and the "/AJAX" path.

Tested on live equipment. 

